### PR TITLE
Generalize ISR handling and some interrupt code

### DIFF
--- a/arch/i386/cpu/apic.c
+++ b/arch/i386/cpu/apic.c
@@ -360,7 +360,7 @@ int ioapic_set_bus(struct ioapic *ioapic, unsigned int pin, int bus_type)
 
 int ioapic_set_irq(struct ioapic *ioapic, unsigned int pin, int irq)
 {
-    if (pin >= ioapic->irq_count || irq > NUM_INTERRUPT_VECTORS - IRQ_BASE)
+    if (pin >= ioapic->irq_count || irq > X86_NUM_INTERRUPT_VECTORS - IRQ_BASE)
         return EINVAL;
 
     ioapic->pins[pin].irq = irq;
@@ -724,7 +724,7 @@ void lapic_error_handler(void)
 {
     uint32_t esr;
 
-    system_pic->eoi(0);
+    system_pic->eoi(APIC_VEC_ERROR);
 
     /* clear existing errors and update ESR */
     lapic_reg_write(APIC_REG_ESR, 0);
@@ -805,7 +805,7 @@ static void lapic_send_ipi_phys(uint8_t vec,
 
 static int lapic_send_ipi_flat(unsigned int vec, cpumask_t cpumask)
 {
-    if (vec < IRQ_BASE || vec > NUM_INTERRUPT_VECTORS)
+    if (vec < IRQ_BASE || vec > X86_NUM_INTERRUPT_VECTORS)
         return EINVAL;
 
     lapic_send_ipi(vec, cpumask & 0xFF, 0, APIC_INT_MODE_FIXED);
@@ -822,7 +822,7 @@ static int lapic_send_ipi_cluster(unsigned int vec, cpumask_t cpumask)
     int cluster, ids, cpu_id;
     cpumask_t online;
 
-    if (vec < IRQ_BASE || vec > NUM_INTERRUPT_VECTORS)
+    if (vec < IRQ_BASE || vec > X86_NUM_INTERRUPT_VECTORS)
         return EINVAL;
 
     online = cpumask_online();

--- a/arch/i386/cpu/idt.c
+++ b/arch/i386/cpu/idt.c
@@ -24,9 +24,9 @@
 #include "exceptions.h"
 #include "pic8259.h"
 
-static uint64_t idt[IDT_ENTRIES];
+static uint64_t idt[X86_NUM_INTERRUPT_VECTORS];
 
-extern uint64_t irq_fn[NUM_INTERRUPT_VECTORS - NUM_EXCEPTION_VECTORS];
+extern uint64_t irq_fn[X86_NUM_ASSIGNABLE_VECTORS];
 extern void idt_load(void *base, size_t s);
 
 static uint64_t idt_pack(uintptr_t intfn, uint16_t selector, uint8_t gate)
@@ -44,7 +44,10 @@ static uint64_t idt_pack(uintptr_t intfn, uint16_t selector, uint8_t gate)
 }
 
 // Sets a single interrupt vector in the IDT.
-void idt_set(size_t vector, void (*intfn)(void), uint16_t selector, uint8_t gate)
+void idt_set(size_t vector,
+             void (*intfn)(void),
+             uint16_t selector,
+             uint8_t gate)
 {
     idt[vector] = idt_pack((uintptr_t)intfn, selector, gate);
 }

--- a/arch/i386/cpu/percpu.c
+++ b/arch/i386/cpu/percpu.c
@@ -1,6 +1,6 @@
 /*
  * arch/i386/cpu/percpu.c
- * Copyright (C) 2016-2017 Alexei Frolov
+ * Copyright (C) 2021 Alexei Frolov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +20,10 @@
 #include <radix/percpu.h>
 #include <radix/smp.h>
 
+#include <stdbool.h>
+
+#include "exceptions.h"
+
 #define BOOT_PERCPU_OFFSET 0
 
 DEFINE_PER_CPU(unsigned long, __this_cpu_offset);
@@ -30,21 +34,16 @@ void arch_percpu_init_early(void)
     this_cpu_write(__this_cpu_offset, BOOT_PERCPU_OFFSET);
 }
 
-/*
- * arch_percpu_init:
- * Initialize all architecture-specific per-CPU variables.
- */
-int arch_percpu_init(int ap)
+// Initialize all architecture-specific per-CPU variables.
+int arch_percpu_init(bool is_ap)
 {
     addr_t offset;
 
-    if (ap) {
-        /* TODO */
+    if (is_ap) {
+        this_cpu_write(unhandled_exceptions, 0);
     } else {
-        /*
-         * Complete BSP per-CPU initialization by setting its
-         * fsbase to its newly allocated per-CPU section offset.
-         */
+        // Complete BSP per-CPU initialization by setting its
+        // fsbase to its newly allocated per-CPU section offset.
         offset = __percpu_offset[processor_id()];
         gdt_set_fsbase(offset);
         this_cpu_write(__this_cpu_offset, offset);

--- a/arch/i386/include/radix/asm/apic.h
+++ b/arch/i386/include/radix/asm/apic.h
@@ -22,15 +22,6 @@
 #include <radix/mm_types.h>
 #include <radix/types.h>
 
-#define APIC_VEC_TIMER    0x22
-#define APIC_VEC_NMI      0xE0
-#define APIC_VEC_SMI      0xE1
-#define APIC_VEC_EXTINT   0xE2
-#define APIC_VEC_ERROR    0xE3
-#define APIC_VEC_THERMAL  0xE4
-#define APIC_VEC_CMCI     0xE5
-#define APIC_VEC_SPURIOUS 0xFF
-
 extern paddr_t lapic_phys_base;
 extern addr_t lapic_virt_base;
 extern unsigned int ioapics_available;

--- a/arch/i386/include/radix/asm/idt.h
+++ b/arch/i386/include/radix/asm/idt.h
@@ -20,9 +20,8 @@
 #define ARCH_I386_RADIX_IDT_H
 
 #include <radix/asm/gdt.h>
+#include <radix/irq.h>
 #include <radix/types.h>
-
-#define IDT_ENTRIES 256
 
 void idt_init_early(void);
 void idt_init(void);

--- a/arch/i386/include/radix/asm/ipi.h
+++ b/arch/i386/include/radix/asm/ipi.h
@@ -1,6 +1,6 @@
 /*
  * arch/i386/include/radix/asm/ipi.h
- * Copyright (C) 2017 Alexei Frolov
+ * Copyright (C) 2021 Alexei Frolov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,11 +19,6 @@
 #ifndef ARCH_I386_RADIX_IPI_H
 #define ARCH_I386_RADIX_IPI_H
 
-#define IPI_VEC_PANIC         0xF0
-#define IPI_VEC_TLB_SHOOTDOWN 0xF1
-#define IPI_VEC_TIMER_ACTION  0xF2
-#define IPI_VEC_SCHED_WAKE    0xF3
-
 #define __arch_send_panic_ipi       i386_send_panic_ipi
 #define __arch_send_timer_ipi       i386_send_timer_ipi
 #define __arch_send_sched_wake(cpu) i386_send_sched_wake(cpu)
@@ -32,4 +27,4 @@ void i386_send_panic_ipi(void);
 void i386_send_timer_ipi(void);
 void i386_send_sched_wake(int cpu);
 
-#endif /* ARCH_I386_RADIX_IPI_H */
+#endif  // ARCH_I386_RADIX_IPI_H

--- a/arch/i386/include/radix/asm/irq.h
+++ b/arch/i386/include/radix/asm/irq.h
@@ -1,6 +1,6 @@
 /*
  * arch/i386/include/radix/asm/irq.h
- * Copyright (C) 2016-2017 Alexei Frolov
+ * Copyright (C) 2021 Alexei Frolov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,54 +23,19 @@
 #error only <radix/irq.h> can be included directly
 #endif
 
-#define ISA_IRQ_COUNT 16
-#define IRQ_BASE      0x20
+#include <radix/asm/pic.h>
+#include <radix/asm/vectors.h>
+#include <radix/compiler.h>
+#include <radix/percpu.h>
+#include <radix/types.h>
 
 #define VECTOR_TO_IRQ(vec) ((vec)-IRQ_BASE)
 #define IRQ_TO_VECTOR(irq) ((irq) + IRQ_BASE)
-
-#define __ARCH_TIMER_IRQ 0x0
-#define __ARCH_KBD_IRQ   0x1
-
-#define __ARCH_TIMER_VECTOR   IRQ_TO_VECTOR(__ARCH_TIMER_IRQ)
-#define __ARCH_KBD_VECTOR     IRQ_TO_VECTOR(__ARCH_KBD_IRQ)
-#define __ARCH_SYSCALL_VECTOR 0x80
 
 #define __arch_irq_init      interrupt_init
 #define __arch_in_irq        in_interrupt
 #define __arch_irq_install   install_interrupt_handler
 #define __arch_irq_uninstall uninstall_interrupt_handler
-
-#define NUM_INTERRUPT_VECTORS 256
-#define NUM_EXCEPTION_VECTORS 32
-
-#define X86_EXCEPTION_DE 0x00
-#define X86_EXCEPTION_DB 0x01
-#define X86_EXCEPTION_BP 0x03
-#define X86_EXCEPTION_OF 0x04
-#define X86_EXCEPTION_BR 0x05
-#define X86_EXCEPTION_UD 0x06
-#define X86_EXCEPTION_NM 0x07
-#define X86_EXCEPTION_DF 0x08
-#define X86_EXCEPTION_CP 0x09
-#define X86_EXCEPTION_TS 0x0A
-#define X86_EXCEPTION_NP 0x0B
-#define X86_EXCEPTION_SS 0x0C
-#define X86_EXCEPTION_GP 0x0D
-#define X86_EXCEPTION_PF 0x0E
-#define X86_EXCEPTION_MF 0x10
-#define X86_EXCEPTION_AC 0x11
-#define X86_EXCEPTION_MC 0x12
-#define X86_EXCEPTION_XM 0x13
-#define X86_EXCEPTION_VE 0x14
-#define X86_EXCEPTION_SX 0x1E
-
-#ifdef __KERNEL__
-
-#include <radix/asm/pic.h>
-#include <radix/compiler.h>
-#include <radix/percpu.h>
-#include <radix/types.h>
 
 void interrupt_init(void);
 int in_interrupt(void);
@@ -93,6 +58,4 @@ static __always_inline void __arch_unmask_irq(unsigned int irq)
     system_pic->unmask(irq);
 }
 
-#endif /* __KERNEL__ */
-
-#endif /* ARCH_I386_RADIX_IRQ_H */
+#endif  // ARCH_I386_RADIX_IRQ_H

--- a/arch/i386/include/radix/asm/percpu.h
+++ b/arch/i386/include/radix/asm/percpu.h
@@ -21,6 +21,8 @@
 
 #include <radix/asm/assembler.h>
 
+#include <stdbool.h>
+
 // Heavily inspired by Linux
 // include/linux/percpu-defs.h
 
@@ -87,6 +89,6 @@
 DECLARE_PER_CPU(unsigned long, __this_cpu_offset);
 
 void arch_percpu_init_early(void);
-int arch_percpu_init(int ap);
+int arch_percpu_init(bool is_ap);
 
 #endif  // ARCH_I386_RADIX_PERCPU_H

--- a/arch/i386/include/radix/asm/regs.h
+++ b/arch/i386/include/radix/asm/regs.h
@@ -1,6 +1,6 @@
 /*
  * arch/i386/include/radix/asm/regs.h
- * Copyright (C) 2016-2017 Alexei Frolov
+ * Copyright (C) 2021 Alexei Frolov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,8 +22,10 @@
 #include <radix/mm_types.h>
 #include <radix/types.h>
 
+// Registers in an x86 system. Must be kept in sync with regs_asm.h and
+// arch/i386/irq/isr.S.
 struct regs {
-    /* gprs */
+    // GPRs
     uint32_t di;
     uint32_t si;
     uint32_t sp;
@@ -33,7 +35,7 @@ struct regs {
     uint32_t cx;
     uint32_t ax;
 
-    /* segment registers */
+    // Segment registers
     uint32_t gs;
     uint32_t fs;
     uint32_t es;
@@ -43,10 +45,16 @@ struct regs {
 
     uint32_t ip;
     uint32_t flags;
+
+    // TODO(frolv): FPU, SSE, etc.
 };
 
+// The layout of the stack during an interrupt, as set up by _interrupt_common
+// in arch/i386/irq/isr.S.
 struct interrupt_context {
     struct regs regs;
+    uint32_t handler;
+    uint32_t code;
     uint32_t ip;
     uint32_t cs;
     uint32_t flags;
@@ -56,4 +64,4 @@ struct interrupt_context {
 
 void kthread_reg_setup(struct regs *r, addr_t stack, addr_t func, addr_t arg);
 
-#endif /* ARCH_I386_RADIX_REGS_H */
+#endif  // ARCH_I386_RADIX_REGS_H

--- a/arch/i386/include/radix/asm/vectors.h
+++ b/arch/i386/include/radix/asm/vectors.h
@@ -1,0 +1,92 @@
+/*
+ * arch/i386/include/radix/asm/irq.h
+ * Copyright (C) 2021 Alexei Frolov
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARCH_I386_RADIX_VECTORS_H
+#define ARCH_I386_RADIX_VECTORS_H
+
+// Interrupt vector setup for an x86 system.
+
+#define X86_NUM_INTERRUPT_VECTORS 256
+#define X86_NUM_EXCEPTION_VECTORS 32
+#define X86_NUM_RESERVED_VECTORS  64
+#define X86_NUM_ASSIGNABLE_VECTORS                           \
+    (X86_NUM_INTERRUPT_VECTORS - X86_NUM_EXCEPTION_VECTORS - \
+     X86_NUM_RESERVED_VECTORS)
+
+#define ISA_IRQ_COUNT 16
+#define IRQ_BASE      0x20
+
+// Vectors 0 through 31 are reserved for exceptions.
+
+#define X86_FIRST_EXCEPTION_VECTOR 0
+#define X86_LAST_EXCEPTION_VECTOR  (IRQ_BASE - 1)
+
+#define X86_EXCEPTION_DE 0x00
+#define X86_EXCEPTION_DB 0x01
+#define X86_EXCEPTION_BP 0x03
+#define X86_EXCEPTION_OF 0x04
+#define X86_EXCEPTION_BR 0x05
+#define X86_EXCEPTION_UD 0x06
+#define X86_EXCEPTION_NM 0x07
+#define X86_EXCEPTION_DF 0x08
+#define X86_EXCEPTION_CP 0x09
+#define X86_EXCEPTION_TS 0x0A
+#define X86_EXCEPTION_NP 0x0B
+#define X86_EXCEPTION_SS 0x0C
+#define X86_EXCEPTION_GP 0x0D
+#define X86_EXCEPTION_PF 0x0E
+#define X86_EXCEPTION_MF 0x10
+#define X86_EXCEPTION_AC 0x11
+#define X86_EXCEPTION_MC 0x12
+#define X86_EXCEPTION_XM 0x13
+#define X86_EXCEPTION_VE 0x14
+#define X86_EXCEPTION_SX 0x1E
+
+// IRQs start following the reserved exception vectors. The first 16 (vectors
+// 32 through 47) are ISA IRQs. The system PIC may additionally have more IRQs
+// on top of these. (For example, IOAPICs often have 24 in total.) The ISA and
+// PIC vectors can be requested explicitly.
+//
+// After the PIC IRQs, the majority of interrupt vectors fall into an assignable
+// pool. Drivers can request a vector when they are loaded and the system will
+// find one from this pool.
+
+#define X86_FIRST_ASSIGNABLE_VECTOR IRQ_BASE
+#define X86_LAST_ASSIGNABLE_VECTOR  (X86_FIRST_RESERVED_VECTOR - 1)
+
+// Finally, the system reserves the last 64 vectors (0xc0 - 0xff) for its own
+// use.
+
+#define X86_FIRST_RESERVED_VECTOR \
+    (X86_NUM_INTERRUPT_VECTORS - X86_NUM_RESERVED_VECTORS)
+
+#define IPI_VEC_PANIC         0xC0
+#define IPI_VEC_TLB_SHOOTDOWN 0xC1
+#define IPI_VEC_TIMER_ACTION  0xC2
+#define IPI_VEC_SCHED_WAKE    0xC3
+
+#define APIC_VEC_TIMER    0xE0
+#define APIC_VEC_NMI      0xE1
+#define APIC_VEC_SMI      0xE2
+#define APIC_VEC_EXTINT   0xE3
+#define APIC_VEC_ERROR    0xE4
+#define APIC_VEC_THERMAL  0xE5
+#define APIC_VEC_CMCI     0xE6
+#define APIC_VEC_SPURIOUS 0xE7
+
+#endif  // ARCH_I386_RADIX_VECTORS_H

--- a/arch/i386/irq/interrupts.c
+++ b/arch/i386/irq/interrupts.c
@@ -1,6 +1,6 @@
 /*
  * arch/i386/irq/interrupts.c
- * Copyright (C) 2016-2017 Alexei Frolov
+ * Copyright (C) 2021 Alexei Frolov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,14 +38,16 @@ static void irq_nop(void *device);
 #define DEFAULT_SHARED_VECTOR IRQ_TO_VECTOR(9)
 
 /* interrupt handler functions */
-static struct irq_descriptor irq_descriptors[NUM_INTERRUPT_VECTORS] = {
-    [0 ... NUM_INTERRUPT_VECTORS - 1] = {
+static struct irq_descriptor irq_descriptors[X86_NUM_INTERRUPT_VECTORS] = {
+    [0 ... X86_NUM_INTERRUPT_VECTORS - 1] = {
         .handler = irq_nop, .device = NULL, .flags = 0, .next = NULL}};
 
-static uint8_t num_irq_descriptors[NUM_INTERRUPT_VECTORS] = {
-    [0 ... NUM_INTERRUPT_VECTORS - 1] = 1};
+static uint8_t num_irq_descriptors[X86_NUM_INTERRUPT_VECTORS] = {
+    [0 ... X86_NUM_INTERRUPT_VECTORS - 1] = 1};
 
 static unsigned int next_shared_vector;
+
+static spinlock_t irq_vector_spinlock = SPINLOCK_INIT;
 
 static void __add_irq_desc(struct irq_descriptor *head,
                            struct irq_descriptor *desc)
@@ -85,10 +87,11 @@ static int __find_available_vector(unsigned long flags)
     unsigned int vector;
 
     vector = IRQ_BASE + system_pic->irq_count;
-    for (; vector < NUM_INTERRUPT_VECTORS; ++vector) {
+    for (; vector <= X86_LAST_ASSIGNABLE_VECTOR; ++vector) {
         desc = &irq_descriptors[vector];
-        if (!(desc->flags & IRQ_RESERVED) && desc->handler == irq_nop)
+        if (!(desc->flags & IRQ_RESERVED) && desc->handler == irq_nop) {
             return vector;
+        }
     }
 
     /* no IRQs available and device doesn't allow sharing */
@@ -108,16 +111,17 @@ static void __update_next_shared_vector(void)
 
     if (!next_shared_vector) {
         next_shared_vector = IRQ_BASE + system_pic->irq_count;
-        end = NUM_INTERRUPT_VECTORS - 1;
+        end = X86_LAST_ASSIGNABLE_VECTOR;
     } else if (next_shared_vector == IRQ_BASE + system_pic->irq_count) {
-        end = NUM_INTERRUPT_VECTORS - 1;
+        end = X86_LAST_ASSIGNABLE_VECTOR;
     } else {
         end = next_shared_vector - 1;
     }
 
     for (; next_shared_vector != end; ++next_shared_vector) {
-        if (next_shared_vector >= NUM_INTERRUPT_VECTORS)
+        if (next_shared_vector > X86_LAST_ASSIGNABLE_VECTOR) {
             next_shared_vector = IRQ_BASE + system_pic->irq_count;
+        }
 
         desc = &irq_descriptors[next_shared_vector];
         if (!(desc->flags & IRQ_RESERVED) &&
@@ -131,11 +135,14 @@ static void __update_next_shared_vector(void)
 
 int __arch_request_irq(struct irq_descriptor *desc)
 {
-    int vector;
+    unsigned long irqstate;
+    spin_lock_irq(&irq_vector_spinlock, &irqstate);
 
-    vector = __find_available_vector(desc->flags);
-    if (vector < 0)
+    int vector = __find_available_vector(desc->flags);
+    if (vector < 0) {
+        spin_unlock_irq(&irq_vector_spinlock, irqstate);
         return vector;
+    }
 
     if (irq_descriptors[vector].handler == irq_nop) {
         memcpy(&irq_descriptors[vector], desc, sizeof *desc);
@@ -146,6 +153,7 @@ int __arch_request_irq(struct irq_descriptor *desc)
     }
     __update_next_shared_vector();
 
+    spin_unlock_irq(&irq_vector_spinlock, irqstate);
     return VECTOR_TO_IRQ(vector);
 }
 
@@ -154,18 +162,24 @@ int __arch_request_fixed_irq(unsigned int irq,
                              irq_handler_t handler)
 {
     struct irq_descriptor *desc;
+    unsigned long irqstate;
     unsigned int vector;
 
-    if (irq >= system_pic->irq_count)
+    if (irq >= system_pic->irq_count) {
         return EINVAL;
+    }
+
+    spin_lock_irq(&irq_vector_spinlock, &irqstate);
 
     vector = IRQ_TO_VECTOR(irq);
     if (irq_descriptors[vector].handler == irq_nop) {
         desc = &irq_descriptors[vector];
     } else {
         desc = kmalloc(sizeof *desc);
-        if (!desc)
+        if (!desc) {
+            spin_unlock_irq(&irq_vector_spinlock, irqstate);
             return ENOMEM;
+        }
 
         __add_irq_desc(&irq_descriptors[vector], desc);
         ++num_irq_descriptors[vector];
@@ -175,6 +189,7 @@ int __arch_request_fixed_irq(unsigned int irq,
     desc->device = device;
     desc->next = NULL;
 
+    spin_unlock_irq(&irq_vector_spinlock, irqstate);
     return 0;
 }
 
@@ -184,17 +199,19 @@ int __arch_request_fixed_irq(unsigned int irq,
  */
 void __arch_release_irq(unsigned int irq, void *device)
 {
-    struct irq_descriptor *desc, *tmp;
-    unsigned int vector;
+    unsigned long irqstate;
+    spin_lock_irq(&irq_vector_spinlock, &irqstate);
 
-    vector = IRQ_TO_VECTOR(irq);
-    desc = __find_irq_desc(vector, device);
-    if (!desc)
+    unsigned int vector = IRQ_TO_VECTOR(irq);
+    struct irq_descriptor *desc = __find_irq_desc(vector, device);
+    if (!desc) {
+        spin_unlock_irq(&irq_vector_spinlock, irqstate);
         return;
+    }
 
     if (desc == &irq_descriptors[vector]) {
         if (desc->next) {
-            tmp = desc->next;
+            struct irq_descriptor *tmp = desc->next;
             memcpy(desc, desc->next, sizeof *desc);
             --num_irq_descriptors[vector];
             kfree(tmp);
@@ -202,29 +219,28 @@ void __arch_release_irq(unsigned int irq, void *device)
             desc->handler = irq_nop;
             desc->device = NULL;
             desc->flags = 0;
-            if (irq <= system_pic->irq_count)
+            if (irq <= system_pic->irq_count) {
                 system_pic->mask(irq);
+            }
         }
     } else {
         __del_irq_desc(&irq_descriptors[vector].next, desc);
         kfree(desc);
         --num_irq_descriptors[vector];
     }
+
+    spin_unlock_irq(&irq_vector_spinlock, irqstate);
 }
 
-/*
- * interrupt_handler:
- * Common interrupt handler. Calls handler functions for specified interrupt.
- */
-void interrupt_handler(__unused struct regs *regs, int intno)
+// Common interrupt handler. Calls handler functions for specified interrupt.
+void interrupt_handler(__unused struct interrupt_context *intctx, int vector)
 {
-    struct irq_descriptor *desc;
+    system_pic->eoi(vector);
 
-    system_pic->eoi(intno);
-
-    desc = &irq_descriptors[intno];
-    for (; desc; desc = desc->next)
+    struct irq_descriptor *desc = &irq_descriptors[vector];
+    for (; desc; desc = desc->next) {
         desc->handler(desc->device);
+    }
 }
 
 int in_interrupt(void) { return !!this_cpu_read(interrupt_depth); }
@@ -234,8 +250,9 @@ void interrupt_init(void)
     size_t irq;
 
     /* reserve all PIC interrupts */
-    for (irq = 0; irq < system_pic->irq_count; ++irq)
+    for (irq = 0; irq < system_pic->irq_count; ++irq) {
         irq_descriptors[IRQ_TO_VECTOR(irq)].flags |= IRQ_RESERVED;
+    }
 
     irq_descriptors[APIC_VEC_NMI].flags |= IRQ_RESERVED;
     irq_descriptors[APIC_VEC_SMI].flags |= IRQ_RESERVED;

--- a/arch/i386/irq/isr.S
+++ b/arch/i386/irq/isr.S
@@ -1,5 +1,5 @@
 #
-# arch/i386/irq/intgates.S
+# arch/i386/irq/isr.S
 # Copyright (C) 2021 Alexei Frolov
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,9 +16,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Interrupt service routines for an i386 system.
+
 #include <radix/asm/regs_asm.h>
+#include <radix/asm/vectors.h>
 #include <radix/assembler.h>
-#include <radix/irq.h>
 
 .macro UNHANDLED_EXCEPTION
 	call exception_unhandled
@@ -26,7 +28,6 @@
 .endm
 
 # Per-CPU variable to track the number of unhandled exceptions.
-# TODO(frolv): when APs come online, they should reset this to zero.
 DEFINE_PER_CPU(unhandled_exceptions)
 	.long 0
 DEFINE_PER_CPU_END()
@@ -35,10 +36,30 @@ DEFINE_PER_CPU(interrupt_depth)
 	.long 0
 DEFINE_PER_CPU_END()
 
+.macro POP_STRUCT_REGS
+	popl %edi
+	popl %esi
+	# skip original esp
+	addl $4, %esp
+	popl %ebp
+	popl %ebx
+	popl %edx
+	popl %ecx
+	popl %eax
+	# Skip fs and gs -- these are specific to the CPU.
+	addl $8, %esp
+	pop %es
+	pop %ds
+	# Skip cs, ss, eip, and eflags, as they'll be handled by the iret.
+	addl $16, %esp
+.endm
+
 # Function for unimplemented exception handlers.
 exception_unhandled:
 	incl THIS_CPU_VAR(unhandled_exceptions)
 	ret
+
+# TODO(frolv): Begin legacy code. Should be migrated to use _interrupt_common.
 
 BEGIN_FUNC(div_error)
 	pushl $0
@@ -159,6 +180,43 @@ END_FUNC(security_exception)
 	movl %eax, REGS_IP(%esp)
 .endm
 
+# store GPRs, call exception handler function, and restore context
+exception_common:
+	incl THIS_CPU_VAR(interrupt_depth)
+	BUILD_STRUCT_REGS 8
+	# exception error code in eax, handler function in ecx,
+	# base of struct regs in edx
+	movl 68(%esp), %eax
+	movl 64(%esp), %ecx
+	movl %esp, %edx
+	pushl %eax
+	pushl %edx
+	cld
+	call *%ecx
+	addl $8, %esp
+	POP_STRUCT_REGS
+	addl $8, %esp
+	decl THIS_CPU_VAR(interrupt_depth)
+	iret
+
+BEGIN_FUNC(lapic_error)
+	pushl $lapic_error_handler
+	jmp irq_noargs_common
+END_FUNC(lapic_error)
+
+irq_noargs_common:
+	incl THIS_CPU_VAR(interrupt_depth)
+	BUILD_STRUCT_REGS 4
+	movl 64(%esp), %eax
+	cld
+	call *%eax
+	POP_STRUCT_REGS
+	addl $4, %esp
+	decl THIS_CPU_VAR(interrupt_depth)
+	iret
+
+# TODO(frolv): End of legacy code.
+
 # Creates a `struct regs` on the stack with the values of the current registers
 # and the context pushed at the start of an interrupt.
 #
@@ -195,130 +253,121 @@ END_FUNC(security_exception)
 	movl %eax, REGS_IP(%esp)
 .endm
 
-.macro POP_STRUCT_REGS
-	popl %edi
-	popl %esi
-	# skip original esp
-	addl $4, %esp
-	popl %ebp
-	popl %ebx
-	popl %edx
-	popl %ecx
-	popl %eax
-	# Skip fs and gs -- these are specific to the CPU.
-	addl $8, %esp
-	pop %es
-	pop %ds
-	# Skip cs, ss, eip, and eflags, as they'll be handled by the iret.
-	addl $16, %esp
-.endm
+#
+# Custom kernel IRQ vectors.
+#
 
-# store GPRs, call exception handler function, and restore context
-exception_common:
-	incl THIS_CPU_VAR(interrupt_depth)
-	BUILD_STRUCT_REGS 8
-	# exception error code in eax, handler function in ecx,
-	# base of struct regs in edx
-	movl 68(%esp), %eax
-	movl 64(%esp), %ecx
-	movl %esp, %edx
-	pushl %eax
-	pushl %edx
-	cld
-	call *%ecx
-	addl $8, %esp
-	POP_STRUCT_REGS
-	addl $8, %esp
-	decl THIS_CPU_VAR(interrupt_depth)
-	iret
+BEGIN_FUNC(event_irq)
+	push $APIC_VEC_TIMER
+	push $arch_event_handler
+	jmp _interrupt_common
+END_FUNC(event_irq)
 
-# Generate an array of interrupt entry point functions,
-# with each entry 8 bytes long.
+BEGIN_FUNC(sched_wake)
+	push $IPI_VEC_SCHED_WAKE
+	push $sched_wake_handler
+	jmp _interrupt_common
+END_FUNC(sched_wake)
+
+# Generic IRQ vectors through the exception_handler function.
+#
+# Generate an array of ISR entry points for the assignable IRQ vectors, with
+# each entry being 8 bytes long:
+#
+#   push <vec>            # 2 bytes
+#   jmp <_irq_fn_common>  # 5 bytes
+#   nop                   # 1 byte
+#
+# This is possible through the use of the "PUSH imm8" instruction, which encodes
+# in 2 bytes. However, this instruction only operates on signed 8-bit values.
+# Any value larger than INT8_MAX is interpreted by the assembler as a 16-bit
+# immediate. Therefore, instead of using vectors 0-255, subtract 128 from the
+# pushed values to keep them within the acceptable range.
+#
+# This table is referenced from C via the variable
+#
+#   extern uint64_t irq_fn[X86_NUM_ASSIGNABLE_VECTORS];
+#
+# in arch/i386/cpu/idt.c.
+
+#define __VECTOR_CORRECTION 128
+
 .align 8
 BEGIN_FUNC(irq_fn)
-vector = IRQ_BASE
-.rept (NUM_INTERRUPT_VECTORS - NUM_EXCEPTION_VECTORS)
-	push $(vector - 0x80)
-	jmp interrupt_common
+vector = X86_FIRST_ASSIGNABLE_VECTOR
+.rept X86_NUM_ASSIGNABLE_VECTORS
+	push $(vector - __VECTOR_CORRECTION)
+	jmp _irq_fn_common
 	.align 8
 	vector = vector + 1
 .endr
 END_FUNC(irq_fn)
 
-interrupt_common:
-	incl THIS_CPU_VAR(interrupt_depth)
-	addl $0x80, (%esp)
-	BUILD_STRUCT_REGS 4
-	movl 64(%esp), %eax
-	movl %esp, %edx
-	pushl %eax
-	pushl %edx
-	cld
-	call interrupt_handler
-	addl $8, %esp
-	POP_STRUCT_REGS
-	addl $4, %esp
-	decl THIS_CPU_VAR(interrupt_depth)
-	iret
-
-
+# Fix the pushed vector value on the stack, then push the interrupt handler to
+# put the stack into a valid state for _interrupt_common to process.
 #
-# The interrupt used by radix's event system.
-# Unlike the interrupts above, this may result in a context switch and should
-# allow the values pushed to the stack by the interrupt to be modified from C.
-#
-BEGIN_FUNC(event_irq)
+# Note: This *MUST* be defined directly before _interrupt_common to avoid a
+#       second jump.
+_irq_fn_common:
+	addl $__VECTOR_CORRECTION, (%esp)
+	push $interrupt_handler
+
+# Common handling code for (most) interrupt vectors. At this point, two words
+# are assumed to have already been pushed to the stack: the IRQ handler function
+# and some custom vector-defined value (e.g. error code, vector number,
+_interrupt_common:
 	incl THIS_CPU_VAR(interrupt_depth)
 
-	# Check if the interrupt occurred from user mode (ring 3).
-	testw $0x3, 4(%esp)
-	jnz .Lpush_regs
+	# Check if the interrupt occurred from user mode (ring 3). If it did,
+	# the stack is properly configured, so skip ahead.
+	testw $0x3, 12(%esp)
+	jnz .Lcall_handler
 
 	# Interrupts occuring in ring 0 do not push ss and esp to the stack like
-	# ring 3 interrupts.
+	# their ring 3 counterparts.
 	#
 	# To support uniform handling for both kernel and user threads, ring 0
 	# interrupts imitate the ring 3 stack by inserting the additional
-	# registers where they would have appeared.
+	# registers where they would otherwise have appeared.
 	#
 	# Ring 0 interrupt transformation:
 	#
 	#   1. Initial stack on interrupt entry.
 	#
-	#          +--------+--------+--------+
-	#          | eflags |   cs   |   ip   |
-	#          +--------+--------+--------+
-	#      ESP          8        4        0
-	#                                     ^
+	#     +--------+--------+--------+--------+--------+
+	#     | eflags |   cs   |   ip   |  code  |  func  |
+	#     +--------+--------+--------+--------+--------+
+	#             16       12        8        4        0
+	#                                                  ^
 	#
 	#   2. Shift everything downwards by 8 bytes to make space for the two
 	#      registers. This requires stashing eax at the bottom of the stack
 	#      as it will be clobbered.
 	#
-	#          +--------+--------+--------+--------+--------+--------+
-	#          |        |        | eflags |   cs   |   ip   |   ax   |
-	#          +--------+--------+--------+--------+--------+--------+
-	#      ESP          8        4        0       -4       -8       -12
-	#                                     ^
+	#      +--------+--------+--------+--------+--------+--------+--------+
+	#      |        |        | eflags |   cs   |   ip   |  code  |  func  |
+	#      +--------+--------+--------+--------+--------+--------+--------+
+	#              16       12        8        4        0       -4       -8
+	#                                                   ^
 	#
-	#   3. Insert ss and esp into the new spaces. 12 bytes are added to the
+	#   3. Insert ss and esp into the new spaces. 20 bytes are added to the
 	#      stored esp's value so that it points to where it was before the
 	#      interrupt was triggered.
 	#
-	#          +--------+--------+--------+--------+--------+--------+
-	#          |   ss   |   sp   | eflags |   cs   |   ip   |   ax   |
-	#          +--------+--------+--------+--------+--------+--------+
-	#      ESP          8        4        0       -4       -8       -12
-	#                                     ^
+	#      +--------+--------+--------+--------+--------+--------+--------+
+	#      |   ss   |   sp   | eflags |   cs   |   ip   |  code  |  func  |
+	#      +--------+--------+--------+--------+--------+--------+--------+
+	#              16       12        8        4        0       -4       -8
+	#                                                   ^
 	#
 	#   4. Advance the active esp into to its new position and restore the
 	#      stashed eax. The stack now mimics that of a ring 3 interrupt.
 	#
-	#          +--------+--------+--------+--------+--------+
-	#          |   ss   |   sp   | eflags |   cs   |   ip   |
-	#          +--------+--------+--------+--------+--------+
-	#      ESP         16       12        8        4        0
-	#                                                       ^
+	#      +--------+--------+--------+--------+--------+--------+--------+
+	#      |   ss   |   sp   | eflags |   cs   |   ip   |  code  |  func  |
+	#      +--------+--------+--------+--------+--------+--------+--------+
+	#              24       20       16       12        8        4        0
+	#                                                                     ^
 	#
 	#   5. From here, continue into the main interrupt handler, which will
 	#      save and potentially modify these stored values.
@@ -326,37 +375,57 @@ BEGIN_FUNC(event_irq)
 
 	# Stash eax and shift everything down.
 	movl %eax, -12(%esp)
-	movl (%esp), %eax
+	movl (%esp), %eax    # func
 	movl %eax, -8(%esp)
-	movl 4(%esp), %eax
+	movl 4(%esp), %eax   # code
 	movl %eax, -4(%esp)
-	movl 8(%esp), %eax
+	movl 8(%esp), %eax   # ip
 	movl %eax, (%esp)
-
-	# Insert esp and ss.
-	movl %esp, %eax
-	addl $12, %eax
+	movl 12(%esp), %eax  # cs
 	movl %eax, 4(%esp)
-	movl %ss, %eax
+	movl 16(%esp), %eax  # eflags
 	movl %eax, 8(%esp)
+
+	# Insert the original value of esp and ss.
+	leal 20(%esp), %eax
+	movl %eax, 12(%esp)
+	movl %ss, %eax
+	movl %eax, 16(%esp)
 
 	# Restore eax and move esp to its final position.
 	movl -12(%esp), %eax
 	subl $8, %esp
 
-.Lpush_regs:
-	PUSH_STRUCT_REGS 0
-	pushl %esp
+.Lcall_handler:
+	# Save the task's register state. After this, we're free to clobber.
+	PUSH_STRUCT_REGS 8
+
+	# Load the handler function into ecx and call it with a pointer to the
+        # regs struct (eax) and the pushed error code (edx). Load pushed values
+	# relative to the original esp from the regs struct to be resilient to
+	# any changes in its layout. (Refer to the "diagrams" above.)
+	movl %esp, %eax
+	movl REGS_SP(%eax), %edx
+	movl -28(%edx), %ecx
+	movl -24(%edx), %edx
+	pushl %edx
+	pushl %eax
 	cld
-	call arch_event_handler
-	addl $4, %esp
+	call *%ecx
+	addl $8, %esp
+
+	# Restore the register state (of the original or new task).
 	POP_STRUCT_REGS
+
+	# Skip past the error code and handler function, returning to the
+	# original interrupt stack.
+	addl $8, %esp
 
 	# Check the cs on the stack to see if returning to a ring 3 or ring 0
 	# context. For ring 3, there is nothing to do, as the stack is already
 	# correctly set up.
 	testw $0x3, 4(%esp)
-	jnz .Lfinish_irq
+	jnz .Lfinish_interrupt
 
 	# When returning into a ring 0 context, we may be switching onto a
 	# different stack and must handle this manually. Copy the three pushed
@@ -394,34 +463,17 @@ BEGIN_FUNC(event_irq)
 	movl 4(%eax), %ebx
 	movl (%eax), %eax
 
-.Lfinish_irq:
-	decl THIS_CPU_VAR(interrupt_depth)
-	iret
-END_FUNC(event_irq)
-
-
-# special interrupt vectors
-
-BEGIN_FUNC(lapic_error)
-	pushl $lapic_error_handler
-	jmp irq_noargs_common
-END_FUNC(lapic_error)
-
-irq_noargs_common:
-	incl THIS_CPU_VAR(interrupt_depth)
-	BUILD_STRUCT_REGS 4
-	movl 64(%esp), %eax
-	cld
-	call *%eax
-	POP_STRUCT_REGS
-	addl $4, %esp
+.Lfinish_interrupt:
 	decl THIS_CPU_VAR(interrupt_depth)
 	iret
 
+# Special vectors that don't use the standard interrupt context (typically
+# because they don't require it and have to be fast).
 
-# IPI vectors
-
+# IPI sent by a panicking processor to every other CPU in the system to shut
+# them down.
 BEGIN_FUNC(panic_shutdown)
+	cli
 	hlt
 	jmp panic_shutdown
 END_FUNC(panic_shutdown)
@@ -451,15 +503,3 @@ BEGIN_FUNC(timer_action)
 	pushl $timer_action_handler
 	jmp irq_noargs_common
 END_FUNC(timer_action)
-
-BEGIN_FUNC(sched_wake)
-	incl THIS_CPU_VAR(interrupt_depth)
-	BUILD_STRUCT_REGS 0
-	pushl %esp
-	cld
-	call sched_wake_handler
-	addl $4, %esp
-	POP_STRUCT_REGS
-	decl THIS_CPU_VAR(interrupt_depth)
-	iret
-END_FUNC(sched_wake)

--- a/arch/i386/timers/pit.c
+++ b/arch/i386/timers/pit.c
@@ -176,7 +176,10 @@ static int pit_oneshot_enable(void)
          PIT_CHANNEL_0 | PIT_ACCESS_MODE_LO_HI | PIT_MODE_TERMINAL);
     pit_data_port_write(PIT_CHANNEL_0_PORT, 0);
 
-    idt_set(IRQ_TO_VECTOR(PIT_IRQ), event_irq, 0x08, 0x8E);
+    idt_set(IRQ_TO_VECTOR(PIT_IRQ),
+            event_irq,
+            GDT_OFFSET(GDT_KERNEL_CODE),
+            IDT_32BIT_INTERRUPT_GATE);
     unmask_irq(PIT_IRQ);
     pit_oneshot.flags |= TIMER_ENABLED;
 
@@ -186,7 +189,7 @@ static int pit_oneshot_enable(void)
 static int pit_oneshot_disable(void)
 {
     mask_irq(PIT_IRQ);
-    idt_set(IRQ_TO_VECTOR(PIT_IRQ), NULL, 0, 0);
+    idt_unset(IRQ_TO_VECTOR(PIT_IRQ));
     pit_data_port_write(PIT_CHANNEL_0_PORT, 0);
     pit_oneshot.flags &= ~TIMER_ENABLED;
 

--- a/include/radix/irq.h
+++ b/include/radix/irq.h
@@ -45,16 +45,12 @@ void release_irq(unsigned int irq, void *device);
 #define mask_irq(irq)   __arch_mask_irq(irq)
 #define unmask_irq(irq) __arch_unmask_irq(irq)
 
+#define irq_init __arch_irq_init
+#define in_irq   __arch_in_irq
+
 #endif /* __KERNEL__ */
 
 #include <radix/asm/irq.h>
 #include <radix/irqstate.h>
-
-#define SYSCALL_INTERRUPT 0x80
-
-#define SYSCALL_VECTOR __ARCH_SYSCALL_VECTOR
-
-#define irq_init __arch_irq_init
-#define in_irq   __arch_in_irq
 
 #endif /* RADIX_IRQ_H */


### PR DESCRIPTION
Migrates common IRQs and the sched_wake IPI to use the same interrupt
context stack fixup that the event IRQ uses to have a consistent entry
point for interrupts. CPU exceptions do not yet use this; they will be
migrated in the future.

Additionally, creates a header file with interrupt vector definitions to
have a centralized place where all vectors can be viewed, instead of
having to look across several files. This file also explicitly defines
which vectors are reserved for use by the kernel.